### PR TITLE
login works when entering in incorrect, then correct, credentials

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -39,7 +39,7 @@ const Login = () => {
       })
       .catch((err) => {
         console.log("There was an error", err);
-        dispatch(resetLoginForm());
+        // dispatch(resetLoginForm());
         alert("Invalid Credentials");
       });
   };


### PR DESCRIPTION
Commented out the line that reset the musicAppState when a login failed because the inputs fields were not being reset in the same way.